### PR TITLE
Template fix for figures

### DIFF
--- a/example-markdown/template.latex
+++ b/example-markdown/template.latex
@@ -269,11 +269,6 @@ $if(graphics)$
 \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
 \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
 \makeatother
-% Scale images if necessary, so that they will not overflow the page
-% margins by default, and it is still possible to overwrite the defaults
-% using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
-% Set default figure placement to htbp
 \makeatletter
 \def\fps@figure{htbp}
 \makeatother


### PR DESCRIPTION
Fix in the pandoc template: a figure on any slide currently ruins the layout of the title page.