### PR TITLE
Rename internal \centerbox to avoid conflict

### DIFF
--- a/theme/beamerinnerthemeost.sty
+++ b/theme/beamerinnerthemeost.sty
@@ -61,13 +61,13 @@
 
 
 % https://texwelt.de/fragen/11209/wie-passe-ich-das-circle-aufzahlungszeichen-in-der-beamerklasse-an
-\newcommand\centerbox[1]{$\vcenter{\hbox{#1}}$}
+\newcommand\ost@beamer@centerbox[1]{$\vcenter{\hbox{#1}}$}
 
 \defbeamertemplate*{itemize item}{ost circle}[1]{%
-\centerbox{\tikz\draw[color=OstDark2,fill=OstDark2] (0,0) circle (0.2ex);}}
+\ost@beamer@centerbox{\tikz\draw[color=OstDark2,fill=OstDark2] (0,0) circle (0.2ex);}}
 
 \defbeamertemplate*{itemize subitem}{black circle}[1]{%
-  \centerbox{\tikz\draw[color=OstDark1,fill=OstDark1] (0,0) circle (0.15ex);}}
+  \ost@beamer@centerbox{\tikz\draw[color=OstDark1,fill=OstDark1] (0,0) circle (0.15ex);}}
 
 \defbeamertemplate*{itemize subsubitem}{n-dash}[1]{--}
 


### PR DESCRIPTION
When the [adjustbox](https://www.ctan.org/pkg/adjustbox) package is used, this theme fails with:

    ! LaTeX Error: Command \centerbox already defined.
                   Or name \end... illegal, see p.192 of the manual.

    See the LaTeX manual or LaTeX Companion for explanation.
    Type  H <return>  for immediate help.
     ...

    l.64 \newcommand\centerbox[1]{$\vcenter{\hbox{#1}}$}

Since `\centerbox` is only used internally, it should have a more unique name, see e.g. [macros - What do \makeatletter and \makeatother do? - TeX - LaTeX Stack Exchange](https://tex.stackexchange.com/questions/8351/what-do-makeatletter-and-makeatother-do/8353#8353) as well as [How to Package Your LaTeX Package](http://texdoc.net/texmf-dist/doc/latex/dtxtut/dtxtut.pdf):

![image](https://user-images.githubusercontent.com/625793/92622270-274c1c80-f2c5-11ea-8ca9-b8ec97868f79.png)


