### PR TITLE
Remove lstMakeShortInline

### DIFF
--- a/theme/beamerthemeost.sty
+++ b/theme/beamerthemeost.sty
@@ -60,6 +60,5 @@
   framexbottommargin=0em, 
   aboveskip=1em,
 }
-\lstMakeShortInline|
 
 \mode<all>


### PR DESCRIPTION
Doing this:

    \documentclass{beamer}
    \usetheme{ost}
    \usepackage{standalone}
    \begin{document}
    \end{document}

Fails with

    (/usr/share/texmf-dist/tex/latex/standalone/standalone.sty
    (/usr/share/texmf-dist/tex/latex/tools/shellesc.sty)
    (/usr/share/texmf-dist/tex/latex/xkeyval/xkeyval.sty
    (/usr/share/texmf-dist/tex/generic/xkeyval/xkeyval.tex
    (/usr/share/texmf-dist/tex/generic/xkeyval/xkvutils.tex)))
    ! Missing \endcsname inserted.
    <to be read again>
    \let
    l.193 \@namedef{sa@mode@image|tex}
                                    {%
    ?

Similarly, when the pgf/TikZ is used, it fails with:

    (/usr/share/texmf-dist/tex/generic/pgf/libraries/pgflibraryplothandlers.code.tex)
    ! Missing \endcsname inserted.
    <to be read again>
    \let
    l.1198 ...earrow{name=|<->|,   means={>[sep=0pt].|}}
                                                      %
    ?

It seems like a really bad idea to redefine a character which is used
internally in probably dozens of LaTeX internals to do something
entirely different. It seems like an even worse idea to do this as part
of a theme which doesn't even use that shorthand ;-)