### PR TITLE
Ensure that footnotes are visible

### DIFF
--- a/example-latex/ost-example.tex
+++ b/example-latex/ost-example.tex
@@ -32,7 +32,7 @@
               \end{itemize}
     \end{itemize}
 
-    Das Design ist an die OST Powerpoint Vorlage angelehnt, weitere Verbesserungen nehmen wir sehr gerne unter \href{https://github.com/ost-fh/Latex-Beamer-Theme}{github.com/ost-fh/Latex-Beamer-Theme} entgegen.
+    Das Design ist an die OST Powerpoint Vorlage angelehnt.\footnote{Weitere Verbesserungen nehmen wir sehr gerne unter \href{https://github.com/ost-fh/Latex-Beamer-Theme}{github.com/ost-fh/Latex-Beamer-Theme} entgegen.}
 
 \end{frame}
 

--- a/example-markdown/ost-example.md
+++ b/example-markdown/ost-example.md
@@ -22,4 +22,4 @@ Dies ist ein Beispiel für die Verwendung des OST Latex Beamer Themes.
    - Und so weiter
 
 
-Das Design ist an die OST Powerpoint Vorlage angelehnt, weitere Verbesserungen nehmen wir sehr gerne unter [github.com/ost-fh/Latex-Beamer-Theme](https://github.com/ost-fh/Latex-Beamer-Theme) entgegen.
+Das Design ist an die OST Powerpoint Vorlage angelehnt.^[Weitere Verbesserungen nehmen wir sehr gerne unter [github.com/ost-fh/Latex-Beamer-Theme](https://github.com/ost-fh/Latex-Beamer-Theme) entgegen.]

--- a/theme/beamerouterthemeost.sty
+++ b/theme/beamerouterthemeost.sty
@@ -24,6 +24,7 @@
 \defbeamertemplate*{footline}{ost}
 {
   \leavevmode
+  \vspace{45pt}
   \ifnum \insertpagenumber=1
   \else
     \begin{textblock}{33.88}[0,0](0,17.93)


### PR DESCRIPTION
Hey @misto 

I added a little fix so that footnotes become visible:

![image](https://user-images.githubusercontent.com/6763278/93176249-4b7a8400-f731-11ea-8e6c-85fb17f4c376.png)

I adjusted the example to feature (not necessarily needed):

![image](https://user-images.githubusercontent.com/6763278/93176343-6baa4300-f731-11ea-9092-7dbb7337222d.png)

Gruss,
Stefan